### PR TITLE
fix unmet dependencies and deprecation flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
     "sass": "^1.32.11",
     "web-vitals": "^1.0.1"
   },
+  "devDependencies": {
+    "eslint": "^7.32.0"
+  },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
This add eslint with explicit version dependency (^7.32.0) because newer versions don't work with `package.json` config.
Add the `--openssl-legacy-provider` as mentioned in this issue https://stackoverflow.com/a/73145035