### PR TITLE
BAH-3164 | Add. httpd:2.4.57-alpine As Docker Base Image

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,3 +1,3 @@
-FROM httpd:2.4-alpine
+FROM httpd:2.4.57-alpine
 COPY build/. /usr/local/apache2/htdocs/abha-verification/
 COPY package/docker/httpd.conf /usr/local/apache2/conf


### PR DESCRIPTION
In this PR, the following modifications have been implemented:

**Base Image Update**: The base image `httpd` has been upgraded from version `2.4-alpine` to version `2.4.57-alpine`.